### PR TITLE
Add VSCode dev container file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,56 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM python:3
+
+ENV http_proxy=http://www-proxy.statoil.no:80
+ENV https_proxy=http://www-proxy.statoil.no:80
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Or your actual UID, GID on Linux if not the default 1000
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Copy requirements.txt (if found) to a temp location so we can install it. The `*`
+# is required so COPY doesn't think that part of the command should fail is nothing is
+# found. Also copy "noop.txt" so the COPY instruction copies _something_ to guarantee
+# success somehow.
+COPY *requirements.txt .devcontainer/noop.txt /tmp/pip-tmp/
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install openjdk-8-jdk \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git procps lsb-release \
+    #
+    # Install pylint
+    && pip --disable-pip-version-check --no-cache-dir install pylint \
+    #
+    # Update Python environment based on requirements.txt (if presenet)
+    && if [ -f "/tmp/pip-tmp/requirements.txt" ]; then pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt; fi \
+    && rm -rf /tmp/pip-tmp \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Uncomment the next three lines to add sudo support
+    # && apt-get install -y sudo \
+    # && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    # && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3
+{
+	"name": "Python 3",
+	"context": "..",
+	"dockerFile": "Dockerfile",
+
+	// Uncomment the next line if you want to publish any ports.
+	"appPort": [
+		"3000:3000"
+	],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "",
+
+	// Uncomment the next line to use a non-root user. See https://aka.ms/vscode-remote/containers/non-root-user.
+	// "runArgs": [ "-u", "1000" ],
+
+	"extensions": [
+		"ms-python.python"
+	],
+	"settings": {
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint",
+		"python.linting.enabled": true
+	}
+}

--- a/.devcontainer/noop.txt
+++ b/.devcontainer/noop.txt
@@ -1,0 +1,3 @@
+This file is copied into the container along with requirements.txt* from the
+parent folder. This is done to prevent the Dockerfile COPY instruction from 
+failing if no requirements.txt is found.

--- a/.devcontainer/start-notebook.sh
+++ b/.devcontainer/start-notebook.sh
@@ -1,0 +1,1 @@
+jupyter-notebook --ip=0.0.0.0 --allow-root --port=3000


### PR DESCRIPTION
I created a container configuration file for VS Code remote container extension. It should set up the development environment for the notebooks. 

the startup script for the notebook server can be found under the /.devcontainer folder and maps to the port 3000. 